### PR TITLE
SQL-777: Implementing tag-triggered release upload to public S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 This repository contains a custom Tableau connector for MongoDB Atlas
 SQL, wrapping our JDBC driver (see
 [mongodb/mongo-jdbc-driver](/mongodb/mongo-jdbc-driver)).
+
+The releases are available for download at the following location.  Replace `<plugin-version>` with plugin version:  
+https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongo-tableau-connector/mongodb-jdbc-<plugin-version>.taco

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,74 @@
+# Versioning  
+Versions will follow the [semantic versioning](https://semver.org/) system.  
+The following guidelines will be used to determine when each version component will be updated:
+- **major**: backwards-breaking changes 
+- **minor**: functionality added in a backwards compatible manner
+- **patch**: backwards compatible bug fixes
+
+# Release Process
+### Pre-Release Tasks
+
+#### Start Release Ticket
+Move the JIRA ticket for the release to the "In Progress" state.
+Ensure that its fixVersion matches the version being released.
+
+#### Complete the Release in JIRA
+Go to the [SQL releases page](https://jira.mongodb.org/projects/SQL?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased), and ensure that all the tickets in the fixVersion to be released are closed.
+Ensure that all the tickets have the correct type. Take this opportunity to edit ticket titles if they can be made more descriptive.
+The ticket titles will be published in the changelog.
+
+If you are releasing a patch version but a ticket needs a minor bump, update the fixVersion to be a minor version bump.
+If you are releasing a patch or minor version but a ticket needs a major bump, stop the release process immediately.
+
+The only uncompleted ticket in the release should be the release ticket.
+If there are any remaining tickets that will not be included in this release, remove the fixVersion and assign them a new one if appropriate.
+
+Close the release on JIRA, adding the current date (you may need to ask the SQL project manager to do this).
+
+#### Ensure Evergreen Passing
+Ensure that the build you are releasing is passing the tests on the evergreen waterfall.
+
+### Release Tasks
+
+#### Ensure master up to date
+Ensure you have the `master` branch checked out, and that you have pulled the latest commit from `mongodb/mongo-tableau-connector`.
+
+#### Ensure plugin-version is correct
+Ensure that the `plugin-version` in [manifest.xml](https://github.com/mongodb/mongo-tableau-connector/blob/master/connector/manifest.xml) 
+is updated with the correct version.
+
+#### Create the tag and push
+Create an annotated tag and push it:
+```
+git tag -a -m X.Y.Z vX.Y.Z
+git push --tags
+```
+This should trigger an Evergreen version that can be viewed on the [mongo-tableau-connector waterfall](https://evergreen.mongodb.com/waterfall/mongo-tableau-connector).
+If it does not, you may have to ask the project manager to give you the right permissions to do so.
+Make sure to run the 'release' task, if it is not run automatically.
+
+#### Set Evergreen Priorities
+Some evergreen variants may have a long schedule queue.
+To speed up release tasks, you can set the task priority for any variant to 101 for release candidates and 200 for actual releases.
+If you do not have permissions to set priority above 100, ask the project manager to set the
+priority.
+
+### Post-Release Tasks
+
+#### Wait for evergreen
+Wait for the evergreen version to finish, and ensure that the release task completes successfully.
+
+#### Verify release artifacts
+Check that the released TACO file is available at the URL:
+- https://translators-connectors-releases.s3.us-east-1.amazonaws.com/mongo-tableau-connector/mongodb-jdbc-<plugin-version>.taco  
+
+Download and install the TACO file.  
+Verify that it is able to connect to Atlas Data Lake with Tableau, extract data, 
+and add columns to the worksheet.
+
+#### Close Release Ticket
+Move the JIRA ticket tracking this release to the "Closed" state.
+
+#### Ensure next release ticket and fixVersion created
+Ensure that a JIRA ticket tracking the next release has been created
+and is assigned the appropriate fixVersion.

--- a/connector/manifest.xml
+++ b/connector/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='mongodb_jdbc' superclass='jdbc' plugin-version='0.1.0' name='MongoDB Atlas' version='18.1' min-version-tableau='2020.4'>
+<connector-plugin class='mongodb_jdbc' superclass='jdbc' plugin-version='0.0.0' name='MongoDB Atlas' version='18.1' min-version-tableau='2020.4'>
   <vendor-information>
       <company name="MongoDB"/>
       <support-link url="https://support.mongodb.com"/>

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -51,15 +51,31 @@ functions:
         local_file: mongo-tableau-connector/mongodb_jdbc.taco
         bucket: mciuploads
 
+  "fetch signed connector":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongo-tableau-connector/artifacts/${version_id}/mongodb_jdbc-signed.taco
+        local_file: mongo-tableau-connector/mongodb_jdbc-signed.taco
+        bucket: mciuploads
+
   "generate expansions":
     - command: shell.exec
       params:
         shell: bash
         working_dir: mongo-tableau-connector
         script: |
+          export MONGO_TABLEAU_CONNECTOR_VERSION=$(git describe --always)
+          export MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET=translators-connectors-releases
+          git describe --exact-match HEAD || MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET=mciuploads
+
           cat <<EOT > expansions.yml
+          MONGO_TABLEAU_CONNECTOR_VERSION: "$MONGO_TABLEAU_CONNECTOR_VERSION"
+          MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET: "$MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET"
           prepare_shell: |
             set -o errexit
+            export MONGO_TABLEAU_CONNECTOR_VERSION="$MONGO_TABLEAU_CONNECTOR_VERSION"
           EOT
     - command: expansions.update
       params:
@@ -137,6 +153,18 @@ functions:
         permissions: public-read
         display_name: "Tableau Connector Packaging Logfile"
 
+  "upload release":
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongo-tableau-connector/mongodb_jdbc-signed.taco
+        remote_file: mongo-tableau-connector/mongodb-jdbc-${MONGO_TABLEAU_CONNECTOR_VERSION}.taco
+        bucket: ${MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET}
+        permissions: public-read
+        display_name: mongodb-jdbc-${MONGO_TABLEAU_CONNECTOR_VERSION}.taco
+        content_type: application/octet-stream
+
   "upload signed connector":
     - command: s3.put
       params:
@@ -184,6 +212,13 @@ tasks:
       - func: "sign archive"
       - func: "upload signed connector"
 
+  - name: release
+    depends_on:
+      - name: sign
+    commands:
+      - func: "fetch signed connector"
+      - func: "upload release"
+
 
 buildvariants:
   - name: ubuntu2004
@@ -192,3 +227,4 @@ buildvariants:
     tasks:
       - name: compile
       - name: sign
+      - name: release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -68,14 +68,19 @@ functions:
         script: |
           export MONGO_TABLEAU_CONNECTOR_VERSION=$(git describe --always)
           export MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET=translators-connectors-releases
-          git describe --exact-match HEAD || MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET=mciuploads
+          export UPDATE_PLUGIN_VERSION=true
+          git describe --exact-match HEAD || MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET=mciuploads &&
+            UPDATE_PLUGIN_VERSION=false
 
           cat <<EOT > expansions.yml
           MONGO_TABLEAU_CONNECTOR_VERSION: "$MONGO_TABLEAU_CONNECTOR_VERSION"
           MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET: "$MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET"
+          UPDATE_PLUGIN_VERSION: "$UPDATE_PLUGIN_VERSION"
           prepare_shell: |
             set -o errexit
             export MONGO_TABLEAU_CONNECTOR_VERSION="$MONGO_TABLEAU_CONNECTOR_VERSION"
+            export MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET="$MONGO_TABLEAU_CONNECTOR_RELEASE_BUCKET"
+            export UPDATE_PLUGIN_VERSION="$UPDATE_PLUGIN_VERSION"
           EOT
     - command: expansions.update
       params:
@@ -128,6 +133,20 @@ functions:
             --comment 'Evergreen Automated Signing (mongo-tableau-connector)' \
             --notary-url http://notary-service.build.10gen.cc:5000 \
             mongodb_jdbc.taco
+
+  "update plugin-version":
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: mongo-tableau-connector
+        silent: false
+        script: |
+          ${prepare_shell}
+
+          if $UPDATE_PLUGIN_VERSION; then
+            sed -i "s/plugin-version='0.0.0'/plugin-version='${MONGO_TABLEAU_CONNECTOR_VERSION}'/g" \
+              connector/manifest.xml
+          fi
 
   "upload packaged connector":
     - command: s3.put
@@ -187,8 +206,8 @@ functions:
           source ./.venv/bin/activate
           # Running packager validation step
           ( cd connector-plugin-sdk/connector-packager && python3 -m connector_packager.package \
-          --validate-only --verbose ../../connector/ --log ../../logs 2>&1 | tee /dev/stdout \
-          | grep "Validation succeeded." >/dev/null)
+             --validate-only --verbose ../../connector/ --log ../../logs 2>&1 | tee /dev/stdout \
+             | grep "Validation succeeded." >/dev/null)
 
 pre:
   - func: "fetch source"
@@ -199,6 +218,7 @@ pre:
 tasks:
   - name: compile
     commands:
+      - func: "update plugin-version"
       - func: "validate connector XML format"
       - func: "build taco bundle"
       - func: "upload packaged connector"


### PR DESCRIPTION
Added instructions to `RELEASE.md`.

Tagged commits will be uploaded to the `translators-connectors-releases` bucket, non-tagged will be uploaded to `mciuploads`.