### PR TITLE
SQL-899: Enable split in Tableau connector

### DIFF
--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -707,8 +707,8 @@
      <argument type='str' />
     </function>
     <native-split-function>
-      <formula part='left'>CASE WHEN %3 = 0 THEN NULL WHEN SPLIT(%1,%2, (%3 - 1)) END</formula>
-      <formula part='right'>CASE WHEN %3 = 0 THEN NULL WHEN SPLIT(%1,%2, %3) END</formula>
+      <formula part='left'>CASE WHEN %3 = 0 THEN NULL ELSE SPLIT(%1,%2, (%3 - 1)) END</formula>
+      <formula part='right'>CASE WHEN %3 = 0 THEN NULL ELSE SPLIT(%1,%2, %3) END</formula>
     </native-split-function>
   </function-map>
   <supported-aggregations>

--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -706,6 +706,10 @@
      <argument type='str' />
      <argument type='str' />
     </function>
+    <native-split-function>
+      <formula part='left'>CASE WHEN %3 = 0 THEN NULL WHEN SPLIT(%1,%2, (%3 - 1)) END</formula>
+      <formula part='right'>CASE WHEN %3 = 0 THEN NULL WHEN SPLIT(%1,%2, %3) END</formula>
+    </native-split-function>
   </function-map>
   <supported-aggregations>
     <aggregation value='AGG_COUNT'/>

--- a/connector/manifest.xml
+++ b/connector/manifest.xml
@@ -18,8 +18,8 @@
       <customization name="CAP_SELECT_INTO" value="no"/>
       <customization name="CAP_SELECT_TOP_INTO" value="no"/>
       <!-- String Splits -->
-      <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="no"/>
-      <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="no"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="yes"/>
+      <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="yes"/>
       <!-- Initial SQL-->
       <customization name="CAP_SUPPORTS_INITIAL_SQL" value="yes"/>
       <!-- Query -->


### PR DESCRIPTION
Works with only native split in the tdd (SPLIT appears in the function list and works as expected), so I did not add the string SPLIT formula.
