### PR TITLE
SQL-907: Enable group by alias capability in manifest

### DIFF
--- a/connector/manifest.xml
+++ b/connector/manifest.xml
@@ -27,6 +27,7 @@
       <customization name="CAP_QUERY_BOOLEXPR_TO_INTEXPR" value="no"/>
       <customization name="CAP_QUERY_CASE_MATCHES_NULL" value="yes"/>
       <customization name="CAP_QUERY_CASE_OUT_NO_BOOL_OPS" value="no"/>
+      <customization name="CAP_QUERY_GROUP_BY_ALIAS" value="yes"/>
       <customization name="CAP_QUERY_GROUP_BY_BOOL" value="yes"/>
       <customization name="CAP_QUERY_HAVING_UNSUPPORTED" value="no"/>
       <customization name="CAP_QUERY_INCLUDE_GROUP_BY_COLUMNS_IN_SELECT" value="no"/>


### PR DESCRIPTION
Verified that TDVT runs successfully with the generated GROUP BY alias queries such as:
```
SELECT "Calcs"."key" AS "TEMP(Test)(3382465274)(0)"
FROM "Calcs"
GROUP BY "TEMP(Test)(3382465274)(0)"
```