### PR TITLE
SQL-910: Add single quotes around the Date variable for the timestamp cast formula

### DIFF
--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -1167,7 +1167,7 @@
     <aggregation value='AGG_SECOND'/>
   </supported-aggregations>
   <sql-format>
-    <format-datetime-literal formula="CAST(%1 AS TIMESTAMP)" format='yyyy-MM-dd HH:mm:ss.SSS' />
+    <format-datetime-literal formula="CAST('%1' AS TIMESTAMP)" format='yyyy-MM-dd HH:mm:ss.SSS' />
     <format-false literal='FALSE' predicate='FALSE' />
     <format-is-distinct value='Formula' />
     <format-order-by value='DirectionOnly' />


### PR DESCRIPTION
We simply missed the quotes around the date variable which is why Tableau does not include them when generating a cast and queries using the cast fail.