### PR TITLE
SQL-999: Add missing datepart 'dayofyear' and 'weekday' from the dateadd formula

### DIFF
--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -1135,6 +1135,8 @@
       <formula part='year'>DATEADD(YEAR, %2, %3)</formula>
       <formula part='month'>DATEADD(MONTH, %2, %3)</formula>
       <formula part='day'>DATEADD(DAY, %2, %3)</formula>
+      <formula part='dayofyear'>DATEADD(DAY, %2, %3)</formula>
+      <formula part='weekday'>DATEADD(DAY, %2, %3)</formula>
       <formula part='hour'>DATEADD(HOUR, %2, %3)</formula>
       <formula part='minute'>DATEADD(MINUTE, %2, %3)</formula>
       <formula part='second'>DATEADD(SECOND, %2, %3)</formula>


### PR DESCRIPTION
Based on Tableau expected results and the example tdd they provided, they are synonymous with day.