### PR TITLE
SQL-1012: Update division operator to return real and not int

### DIFF
--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -739,7 +739,7 @@
       <argument type='real' />
       <argument type='real' />
     </function>
-    <function group='operator' name='/' return-type='int'>
+    <function group='operator' name='/' return-type='real'>
       <formula>(%1 / %2)</formula>
       <argument type='int' />
       <argument type='int' />


### PR DESCRIPTION
The change had been made for the function DIV, but the not the `/` operator