### PR TITLE
SQL-1012: Cast division arguments from int to double

### DIFF
--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -740,7 +740,7 @@
       <argument type='real' />
     </function>
     <function group='operator' name='/' return-type='real'>
-      <formula>(%1 / %2)</formula>
+      <formula>(%1::DOUBLE / %2::DOUBLE)</formula>
       <argument type='int' />
       <argument type='int' />
     </function>


### PR DESCRIPTION
Otherwise the division result is an int which Tableau cast to real instead of having MongoSQL perform the correct operation.