### PR TITLE
SQL-1079: Update formula to match Tableau expected behavior for negative indexes

### DIFF
--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -1164,7 +1164,7 @@
      <argument type='int' />
     </function>
     <function group='string' name='RIGHT' return-type='str'>
-     <formula>(CASE WHEN %2 &lt;= 0 THEN (CASE WHEN %1 IS NULL THEN NULL ELSE '' END) WHEN %2 &gt;= CHAR_LENGTH(%1) THEN %1 ELSE SUBSTRING(%1 FROM (CHAR_LENGTH(%1) - (%2)::INT) FOR (%2)::INT) END)</formula>
+     <formula>(CASE WHEN %2 &lt; 0 THEN NULL WHEN %2 &gt;= CHAR_LENGTH(%1) THEN %1 ELSE SUBSTRING(%1 FROM (CHAR_LENGTH(%1) - FLOOR(%2)::INT) FOR FLOOR(%2)::INT) END)</formula>
      <argument type='str' />
      <argument type='real' />
     </function>


### PR DESCRIPTION
We need to use FLOOR(index) because otherwise when casting to int the value is simply truncated and the result of RIGHT is off by one character.