### PR TITLE
SQL-1023: Formula additions in DatePart for week and weekday

### DIFF
--- a/connector/dialect.tdd
+++ b/connector/dialect.tdd
@@ -1196,8 +1196,15 @@
       <formula>EXTRACT(%1 FROM %2)</formula>
       <!-- MongoDB week number starts at 0 and not 1 -->
       <formula part='week'>(1 + EXTRACT(%1 FROM %2))</formula>
+      <formula part='weekday'>EXTRACT(%1 FROM DATEADD(DAY, 1, %2))</formula>
       <argument type='localstr'/>
       <argument type='datetime'/>
+    </date-function>
+    <date-function name='DATEPART' return-type='int'>
+      <formula part='week'>EXTRACT(%1 FROM DATEADD(DAY, 7 - %3, %2))</formula>
+      <argument type='localstr' />
+      <argument type='datetime' />
+      <argument type='localstr' />
     </date-function>
     <date-function name='DATETRUNC' return-type='datetime'>
       <formula>DATETRUNC(%1, %2)</formula>
@@ -1258,7 +1265,7 @@
       <part name='hour' value='HOUR' />
       <part name='minute' value='MINUTE' />
       <part name='second' value='SECOND' />
-      <part name='weekday' value='WEEKDAY' />
+      <part name='weekday' value='ISO_WEEKDAY' />
       </date-part-group>
     </date-parts>
     <format-date-literal formula="CAST('%1' AS TIMESTAMP)" format='yyyy-MM-dd' />
@@ -1277,6 +1284,7 @@
     </format-select>
     <format-string-literal value='Standard' />
     <format-true literal='TRUE' predicate='TRUE' />
+    <start-of-week-format value='Number' />
     <supported-joins>
       <part name='Inner' />
       <part name='Left' />


### PR DESCRIPTION
Added DATEPART formula with 3 arguments for 'week'. 
Added working implementation for 'weekday' that uses 'iso_week'.  It was previously unimplemented since the keyword 'weekday' is not supported. 

[Test Results](https://docs.google.com/spreadsheets/d/1Tff67qwvutwxwq42Y8XY1L7lc6MIAhBd3MmHOEQt-jI/edit#gid=1628480168)

12 tests are passing that were failing:
DATEPART('week', [date2], 'monday')
DATEPART('week', [datetime0], 'monday')
DATEPART('weekday', [date2], 'monday')
DATEPART('weekday', [date2], 'sunday')
DATEPART('weekday', [datetime0], 'monday')
DATEPART('weekday', [datetime0], 'sunday')
DATEPART('weekday', [date2])
DATEPART('weekday', [datetime0])
setup.BUGS.B24394.simple.xml
DATEPART('weekday', DATETIME(null))
DATEPART('weekday', DATETIME(null), 'sunday')
DATEPART('year',DATEADD('day',-DATEPART('weekday',[date0])+1,[date0]))

