### PR TITLE
SQL-1450: Update signing tasks to use the new Garasign platform - Tableau connector

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -127,7 +127,7 @@ functions:
 
           docker run \
             -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
-            -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
+            -e GRS_CONFIG_USER1_PASSWORD=${tableau_garasign_password} \
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_jarsigner_image} \

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -190,11 +190,31 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: mongo-tableau-connector/mongodb_jdbc-signed.taco
+        local_file: mongo-tableau-connector/mongodb_jdbc.taco
         remote_file: mongo-tableau-connector/artifacts/${version_id}/mongodb_jdbc-signed.taco
         bucket: mciuploads
         permissions: public-read
         content_type: application/octet-stream
+
+  "get signed connector":
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: mongo-tableau-connector/artifacts/${version_id}/mongodb_jdbc-signed.taco
+        bucket: mciuploads
+        local_file: mongo-tableau-connector/mongodb_jdbc-signed.taco
+
+  "verify signed connector":
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: mongo-tableau-connector
+        silent: false
+        script: |
+          ${prepare_shell}
+          
+          jarsigner -verify mongodb_jdbc-signed.taco -verbose -certs -strict
 
   "validate connector XML format":
     - command: shell.exec
@@ -253,6 +273,8 @@ tasks:
       - func: "fetch packaged connector"
       - func: "sign archive"
       - func: "upload signed connector"
+      - func: "get signed connector"
+      - func: "verify signed connector"
 
   - name: release
     git_tag_only: true

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -115,7 +115,7 @@ functions:
         script: |
           ${prepare_shell}
 
-          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
+          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
     - command: shell.exec
       type: system
       params:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -111,6 +111,7 @@ functions:
     - command: shell.exec
       type: system
       params:
+        working_dir: mongo-tableau-connector
         silent: true
         script: |
           ${prepare_shell}

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -194,16 +194,8 @@ functions:
         remote_file: mongo-tableau-connector/artifacts/${version_id}/mongodb_jdbc-signed.taco
         bucket: mciuploads
         permissions: public-read
+        display_name: mongodb-jdbc-signed.taco
         content_type: application/octet-stream
-
-  "get signed connector":
-    - command: s3.get
-      params:
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
-        remote_file: mongo-tableau-connector/artifacts/${version_id}/mongodb_jdbc-signed.taco
-        bucket: mciuploads
-        local_file: mongo-tableau-connector/mongodb_jdbc-signed.taco
 
   "verify signed connector":
     - command: shell.exec
@@ -214,7 +206,7 @@ functions:
         script: |
           ${prepare_shell}
           
-          jarsigner -verify mongodb_jdbc-signed.taco -verbose -certs -strict
+          jarsigner -verify mongodb_jdbc.taco -verbose -certs -strict
 
   "validate connector XML format":
     - command: shell.exec
@@ -272,9 +264,8 @@ tasks:
     commands:
       - func: "fetch packaged connector"
       - func: "sign archive"
-      - func: "upload signed connector"
-      - func: "get signed connector"
       - func: "verify signed connector"
+      - func: "upload signed connector"
 
   - name: release
     git_tag_only: true

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -111,7 +111,6 @@ functions:
     - command: shell.exec
       type: system
       params:
-        working_dir: mongo-tableau-connector
         silent: true
         script: |
           ${prepare_shell}

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -128,7 +128,7 @@ functions:
           ${prepare_shell}
 
           docker run \
-            -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
+            -e GRS_CONFIG_USER1_USERNAME=${tableau_garasign_username} \
             -e GRS_CONFIG_USER1_PASSWORD=${tableau_garasign_password} \
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -116,7 +116,7 @@ functions:
         script: |
           ${prepare_shell}
 
-          echo '${signing_auth_token}' > ./signing_auth_token
+          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
     - command: shell.exec
       type: system
       params:
@@ -125,12 +125,13 @@ functions:
         script: |
           ${prepare_shell}
 
-          /usr/local/bin/notary-client.py \
-            --key-name "tableu-connector" \
-            --auth-token-file ./signing_auth_token \
-            --comment 'Evergreen Automated Signing (mongo-tableau-connector)' \
-            --notary-url http://notary-service.build.10gen.cc:5000 \
-            mongodb_jdbc.taco
+          docker run \
+            -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
+            -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
+            --rm \
+            -v $(pwd):$(pwd) -w $(pwd) \
+            ${garasign_gpg_image} \
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o mongodb_jdbc.taco.sig --detach-sign mongodb_jdbc.taco"
 
   "update plugin-version":
     - command: shell.exec

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -107,7 +107,7 @@ functions:
 
           python3 -m venv .venv
 
-  "sign archive":
+  "sign archive1":
     - command: shell.exec
       type: system
       params:
@@ -117,6 +117,8 @@ functions:
           ${prepare_shell}
 
           docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
+
+  "sign archive2":
     - command: shell.exec
       type: system
       params:
@@ -252,7 +254,8 @@ tasks:
       - name: compile
     commands:
       - func: "fetch packaged connector"
-      - func: "sign archive"
+      - func: "sign archive1"
+      - func: "sign archive2"
       - func: "upload signed connector"
 
   - name: release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -107,18 +107,15 @@ functions:
 
           python3 -m venv .venv
 
-  "sign archive1":
+  "sign archive":
     - command: shell.exec
       type: system
       params:
-        working_dir: mongo-tableau-connector
         silent: true
         script: |
           ${prepare_shell}
 
           docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${release_tools_container_registry}
-
-  "sign archive2":
     - command: shell.exec
       type: system
       params:
@@ -134,23 +131,6 @@ functions:
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_jarsigner_image} \
             /bin/bash -c "jarsigner mongodb_jdbc.taco mongo-authenticode-2021 -tsa http://timestamp.digicert.com"
-
-  "sign archive3":
-    - command: shell.exec
-      type: system
-      params:
-        working_dir: mongo-tableau-connector
-        silent: false
-        script: |
-          ${prepare_shell}
-
-          docker run \
-            -e GRS_CONFIG_USER1_USERNAME=${tableau_garasign_username} \
-            -e GRS_CONFIG_USER1_PASSWORD=${tableau_garasign_password} \
-            --rm \
-            -v $(pwd):$(pwd) -w $(pwd) \
-            ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --yes -v --armor -o mongodb_jdbc.taco.sig --detach-sign mongodb_jdbc.taco"
 
   "update plugin-version":
     - command: shell.exec
@@ -271,8 +251,7 @@ tasks:
       - name: compile
     commands:
       - func: "fetch packaged connector"
-      - func: "sign archive1"
-      - func: "sign archive3"
+      - func: "sign archive"
       - func: "upload signed connector"
 
   - name: release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -115,7 +115,7 @@ functions:
         script: |
           ${prepare_shell}
 
-          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
+          podman login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
     - command: shell.exec
       type: system
       params:
@@ -124,13 +124,14 @@ functions:
         script: |
           ${prepare_shell}
 
-          docker run \
+          podman run \
             -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
             -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
             --rm \
-            -v $(pwd):$(pwd) -w $(pwd) \
-            ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --yes -v --armor -o mongodb_jdbc.taco.sig --detach-sign mongodb_jdbc.taco"
+            -v $(pwd):$(pwd)
+            -w $(pwd) \
+            ${garasign_jarsigner_image} \
+            /bin/bash -c "jarsigner mongodb_jdbc.taco mongo-authenticode-2021 -tsa http://timestamp.digicert.com"
 
   "update plugin-version":
     - command: shell.exec

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -135,6 +135,23 @@ functions:
             ${garasign_jarsigner_image} \
             /bin/bash -c "jarsigner mongodb_jdbc.taco mongo-authenticode-2021 -tsa http://timestamp.digicert.com"
 
+  "sign archive3":
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: mongo-tableau-connector
+        silent: false
+        script: |
+          ${prepare_shell}
+
+          docker run \
+            -e GRS_CONFIG_USER1_USERNAME=${tableau_garasign_username} \
+            -e GRS_CONFIG_USER1_PASSWORD=${tableau_garasign_password} \
+            --rm \
+            -v $(pwd):$(pwd) -w $(pwd) \
+            ${garasign_gpg_image} \
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o mongodb_jdbc.taco.sig --detach-sign mongodb_jdbc.taco"
+
   "update plugin-version":
     - command: shell.exec
       type: system
@@ -255,7 +272,7 @@ tasks:
     commands:
       - func: "fetch packaged connector"
       - func: "sign archive1"
-      - func: "sign archive2"
+      - func: "sign archive3"
       - func: "upload signed connector"
 
   - name: release

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -115,7 +115,7 @@ functions:
         script: |
           ${prepare_shell}
 
-          podman login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
+          docker login --username ${sql_engines_artifactory_username} --password ${sql_engines_artifactory_auth_token} ${artifactory_link}
     - command: shell.exec
       type: system
       params:
@@ -124,12 +124,11 @@ functions:
         script: |
           ${prepare_shell}
 
-          podman run \
+          docker run \
             -e GRS_CONFIG_USER1_USERNAME=${garasign_username} \
             -e GRS_CONFIG_USER1_PASSWORD=${garasign_password} \
             --rm \
-            -v $(pwd):$(pwd)
-            -w $(pwd) \
+            -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_jarsigner_image} \
             /bin/bash -c "jarsigner mongodb_jdbc.taco mongo-authenticode-2021 -tsa http://timestamp.digicert.com"
 


### PR DESCRIPTION
This ticket covers replacing uses of Notary Service with Garasign. In this ticket, I created a few new evergreen variables: `garasign_jarsigner_image`, `release_tools_container_registry`, `sql_engines_artifactory_username`, `sql_engines_artifactory_auth_token`, `tableau_garasign_username`, and `tableau_garasign_password`.