### PR TITLE
SQL-1886: set fn to silent to avoid logging sensitive values

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -120,7 +120,7 @@ functions:
       type: system
       params:
         working_dir: mongo-tableau-connector
-        silent: false
+        silent: true
         script: |
           ${prepare_shell}
 


### PR DESCRIPTION
I missed that this was logged into internal logging in my grep. This sets the function to silent to avoid logging.