### PR TITLE
SQL-1910: account for default version in taco file

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -154,7 +154,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: mongo-tableau-connector/package/mongodb_jdbc.taco
+        local_file: mongo-tableau-connector/package/mongodb_jdbc-v0.0.0.taco
         remote_file: mongo-tableau-connector/artifacts/${version_id}/mongodb_jdbc.taco
         bucket: mciuploads
         permissions: public-read
@@ -205,7 +205,7 @@ functions:
         silent: false
         script: |
           ${prepare_shell}
-          
+
           jarsigner -verify mongodb_jdbc.taco -verbose -certs -strict
 
   "validate connector XML format":

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -120,7 +120,7 @@ functions:
       type: system
       params:
         working_dir: mongo-tableau-connector
-        silent: false
+        silent: true
         script: |
           ${prepare_shell}
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -37,6 +37,8 @@ functions:
           --verbose ../../connector/ --dest ../../package --log ../../logs 2>&1 | tee /dev/stdout \
           | grep "Taco packaged" >/dev/null)
 
+          mv package/mongodb_jdbc-*.taco package/mongodb_jdbc.taco
+
   "fetch source":
     - command: git.get_project
       params:
@@ -154,7 +156,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: mongo-tableau-connector/package/mongodb_jdbc-v0.0.0.taco
+        local_file: mongo-tableau-connector/package/mongodb_jdbc.taco
         remote_file: mongo-tableau-connector/artifacts/${version_id}/mongodb_jdbc.taco
         bucket: mciuploads
         permissions: public-read


### PR DESCRIPTION
There was a change in the tableau connector plugin sdk where taco files now have a default version attached, `-v0.0.0`. This PR accounts for that in our upload task.

Additionally, to comply with security requirements, the signing task is now silent to avoid logging any activity in evergreen.