### PR TITLE
SQL-2419: Move the logging info UI for the Tableau Connector to "Advanced" tab

### DIFF
--- a/connector/connectionFields.xml
+++ b/connector/connectionFields.xml
@@ -1,29 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
-
+  <!-- Main tab fields -->
   <field name="v-mongodb-uri" label="MongoDB URI" value-type="string" category="endpoint" />
-
   <field name="authentication" label="Authentication" category="authentication" value-type="selection" default-value="auth-user-pass">
     <selection-group>
       <option value="auth-user-pass" label="Username and Password"/>
       <option value="auth-none" label="Certificate / Token" />
     </selection-group>
   </field>
-
   <field name="username" label="Username" value-type="string" category="authentication">
     <conditions>
       <condition field="authentication" value="auth-user-pass"/>
     </conditions>
   </field>
-
   <field name="password" label="Password" value-type="string" category="authentication" secure="true">
     <conditions>
       <condition field="authentication" value="auth-user-pass"/>
     </conditions>
   </field>
 
-  <field name="v-loglevel" label="JDBC Log Level" value-type="selection" default-value="log-off" category="general" >
+  <!-- Advanced tab fields -->
+  <field name="v-loglevel" label="JDBC Log Level" value-type="selection" default-value="OFF" category="advanced">
     <selection-group>
       <option value="OFF" label="OFF" />
       <option value="SEVERE" label="SEVERE" />
@@ -33,18 +31,15 @@
       <option value="FINER" label="FINER" />
     </selection-group>
   </field>
-
-  <field name="v-logdir-option" label="Custom JDBC Log Directory" value-type="boolean" category="general"  >
+  <field name="v-logdir-option" label="Custom JDBC Log Directory" value-type="boolean" category="advanced">
     <boolean-options>
       <false-value value="" />
       <true-value value="required" />
     </boolean-options>
   </field>
-
-  <field name="v-log-directory" label="" value-type="string" default-value="" category="general"  >
+  <field name="v-log-directory" label="Log Directory Path" value-type="string" default-value="" category="advanced">
     <conditions>
       <condition field="v-logdir-option" value="required"/>
     </conditions>
   </field>
-
 </connection-fields>

--- a/connector/connectionResolver.tdr
+++ b/connector/connectionResolver.tdr
@@ -7,6 +7,7 @@
         <connection-normalizer>
           <required-attributes>
             <attribute-list>
+              <attr>server</attr>
               <attr>v-mongodb-uri</attr>
               <attr>dbname</attr>
               <attr>authentication</attr>


### PR DESCRIPTION
Adds advanced tab that includes the logging options. 
Added `server` to connectionResolver to fix a warning during connector packaging. 