### PR TITLE
DEVPROD-13291: template authenticode key name

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -135,7 +135,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_jarsigner_image} \
-            /bin/bash -c "jarsigner mongodb_jdbc.taco mongo-authenticode-2021 -tsa http://timestamp.digicert.com"
+            /bin/bash -c "jarsigner mongodb_jdbc.taco ${authenticode_key_name} -tsa http://timestamp.digicert.com"
 
   "update plugin-version":
     - command: shell.exec


### PR DESCRIPTION
This commit templates our authenticode key name in preparation for the authenticode 2021 deprecation. The variable will be added to our Evergreen project as mongo-authenticode-2021, and later updated to 2024 when that certificate is ready.