### PR TITLE
SQL-2513: Rename v-mongodb-uri to `server` for use in Connections label

### DIFF
--- a/connector/connectionBuilder.js
+++ b/connector/connectionBuilder.js
@@ -1,4 +1,4 @@
 (function dsbuilder(attr) {
 
-    var urlBuilder = "jdbc:" + attr["v-mongodb-uri"];
+    var urlBuilder = "jdbc:" + attr["server"];
     return [urlBuilder]; })

--- a/connector/connectionFields.xml
+++ b/connector/connectionFields.xml
@@ -2,7 +2,7 @@
 
 <connection-fields>
   <!-- Main tab fields -->
-  <field name="v-mongodb-uri" label="MongoDB URI" value-type="string" category="endpoint" />
+  <field name="server" label="MongoDB URI" value-type="string" category="endpoint" />
   <field name="authentication" label="Authentication" category="authentication" value-type="selection" default-value="auth-user-pass">
     <selection-group>
       <option value="auth-user-pass" label="Username and Password"/>

--- a/connector/connectionResolver.tdr
+++ b/connector/connectionResolver.tdr
@@ -8,7 +8,6 @@
           <required-attributes>
             <attribute-list>
               <attr>server</attr>
-              <attr>v-mongodb-uri</attr>
               <attr>dbname</attr>
               <attr>authentication</attr>
               <attr>username</attr>


### PR DESCRIPTION
This change will set the server name in the Connection section.  It was initially `v-mongodb-uri` since it contained not only the server name.  But in order to be displayed I'm switching it to the expected `server` it should be enough to help users differentiate their connections.