### PR TITLE
SQL-2644: Rename to MongoDB SQL Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mongo-tableau-connector
 
-This repository contains a custom Tableau connector for MongoDB
+This repository contains a custom Tableau connector for the MongoDB
 SQL Interface, wrapping our JDBC driver (see
 [mongodb/mongo-jdbc-driver](/mongodb/mongo-jdbc-driver)).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mongo-tableau-connector
 
-This repository contains a custom Tableau connector for MongoDB Atlas
-SQL, wrapping our JDBC driver (see
+This repository contains a custom Tableau connector for MongoDB
+SQL Interface, wrapping our JDBC driver (see
 [mongodb/mongo-jdbc-driver](/mongodb/mongo-jdbc-driver)).
 
 The releases are available for download at the following location.  Replace `[plugin-version]` with plugin version:

--- a/connector/manifest.xml
+++ b/connector/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='mongodb_jdbc' superclass='jdbc' plugin-version='0.0.0' name='MongoDB Atlas' version='18.1' min-version-tableau='2020.4'>
+<connector-plugin class='mongodb_jdbc' superclass='jdbc' plugin-version='0.0.0' name='MongoDB SQL Interface' version='18.1' min-version-tableau='2020.4'>
   <vendor-information>
       <company name="MongoDB"/>
       <support-link url="https://support.mongodb.com"/>
@@ -8,7 +8,7 @@
   </vendor-information>
   <connection-customization class="mongodb_jdbc" enabled="true" version="10.0">
     <vendor name="MongoDB"/>
-    <driver name="MongoDB Atlas"/>
+    <driver name="MongoDB SQL Interface"/>
     <customizations>
       <!-- https://tableau.github.io/connector-plugin-sdk/docs/capabilities -->
       <!-- Metadata -->


### PR DESCRIPTION
Renamed from `MongoDB Atlas` to `MongoDB SQL Interface`.

The signing task is currently failing, I'm checking with devprod.