### PR TITLE
SQL-2916: Remove logging related fields

### DIFF
--- a/connector/connectionFields.xml
+++ b/connector/connectionFields.xml
@@ -20,26 +20,4 @@
     </conditions>
   </field>
 
-  <!-- Advanced tab fields -->
-  <field name="v-loglevel" label="JDBC Log Level" value-type="selection" default-value="OFF" category="advanced">
-    <selection-group>
-      <option value="OFF" label="OFF" />
-      <option value="SEVERE" label="SEVERE" />
-      <option value="WARNING" label="WARNING" />
-      <option value="INFO" label="INFO" />
-      <option value="FINE" label="FINE" />
-      <option value="FINER" label="FINER" />
-    </selection-group>
-  </field>
-  <field name="v-logdir-option" label="Custom JDBC Log Directory" value-type="boolean" category="advanced">
-    <boolean-options>
-      <false-value value="" />
-      <true-value value="required" />
-    </boolean-options>
-  </field>
-  <field name="v-log-directory" label="Log Directory Path" value-type="string" default-value="" category="advanced">
-    <conditions>
-      <condition field="v-logdir-option" value="required"/>
-    </conditions>
-  </field>
 </connection-fields>

--- a/connector/connectionProperties.js
+++ b/connector/connectionProperties.js
@@ -11,15 +11,5 @@
     props["dialect"] = "mongosql";
     props["clientInfo"] = "tableau-connector+0.0.0";
 
-    props["LogDir"] = "console";
-    if (attr["v-log-directory"] != null && attr["v-log-directory"] !== "") {
-        props["LogDir"] = attr["v-log-directory"];
-    }
-
-    props["LogLevel"] = "OFF";
-    if(attr["v-loglevel"] != null && attr["v-loglevel"] !== "") {
-        props["LogLevel"] = attr["v-loglevel"];
-    }
-
     return props;
 })

--- a/connector/connectionResolver.tdr
+++ b/connector/connectionResolver.tdr
@@ -12,9 +12,6 @@
               <attr>authentication</attr>
               <attr>username</attr>
               <attr>password</attr>
-              <attr>v-loglevel</attr>
-              <attr>v-logdir-option</attr>
-              <attr>v-log-directory</attr>
             </attribute-list>
           </required-attributes>
         </connection-normalizer>


### PR DESCRIPTION
In preparation for integrating into Tableau Cloud, removing these fields as they can cause issues as they can allow users to redirect where the logs are written to, possibly filling up disk space. 

This change removes the Advanced tab and the options to set the Log Level and Log Directory.  Users will need to set it in a properties file. 
 
Tested manually with Tableau Desktop 2024.1